### PR TITLE
Standardize packaging naming

### DIFF
--- a/pointer/go.mod
+++ b/pointer/go.mod
@@ -1,3 +1,3 @@
-module github.com/SheerHealth/banyan/pointer
+module github.com/sheerhealth/banyan/pointer
 
 go 1.24.3


### PR DESCRIPTION
- Going with `sheerhealth` instead of `SheerHealth`